### PR TITLE
Adds github settings configurations and sets the default branch to main

### DIFF
--- a/.bd.yml
+++ b/.bd.yml
@@ -1,0 +1,6 @@
+name: clj-boot
+team: data
+type: library
+tags:
+  language: clojure
+  dependencies: boot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+.github/settings.yml  @shopsmart/tech-ops-team
+
+# Everything needs to be approved through the data team
+*        @shopsmart/data-team
+

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,8 +1,8 @@
 repository:
   name: clj-boot
-  description: Central place for standard Boot tasks
+  description: "**DEPRECATED** Central place for standard Boot tasks"
   homepage: null
-  topics: ''
+  topics: deprecated,obselete,archived
   private: false
   has_issues: true
   has_projects: true

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,48 @@
+repository:
+  name: clj-boot
+  description: Central place for standard Boot tasks
+  homepage: null
+  topics: ''
+  private: false
+  has_issues: true
+  has_projects: true
+  has_wiki: true
+  has_downloads: true
+  default_branch: main
+  allow_squash_merge: true
+  allow_merge_commit: true
+  allow_rebase_merge: true
+  enable_automated_security_fixes: false
+  enable_vulnerability_alerts: true
+teams:
+  - name: data-team
+    permission: admin
+  - name: deploy
+    permission: pull
+  - name: developers
+    permission: push
+  - name: tech-ops-team
+    permission: admin
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        dismissal_restrictions: {}
+      required_status_checks: null
+      enforce_admins: false
+      required_linear_history: false
+      restrictions: null
+  - name: '*-base'
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: true
+        dismissal_restrictions: {}
+      required_status_checks: null
+      enforce_admins: false
+      required_linear_history: false
+      restrictions: null

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# clj-boot
+# **DEPRECATED** clj-boot
 
 Boot tasks simplifying development and deployment.
 


### PR DESCRIPTION
## Problem
<!-- What are you trying to solve? -->

1. We want Github settings to be properly configured across the organization.
1. We want to rename the default branch to main
1. This repo is unmaintained

## Solution
<!-- How does this solve the problem? -->

1. The [Settings App](https://github.com/probot/settings) can help us manage our Github settings through code.  Not only will this version our settings, it will enable developers to add configurations by simply putting in a PR.  It can help manage labels for us as well which will come in handy if we want to enable auto versioning via tag labels.  The code owners file will enforce that the Tech Ops Team needs to approve a change to the settings.
1. Sets the default branch to main
1. Deprecates this repo.